### PR TITLE
chore(macos): Fix package name

### DIFF
--- a/contrib/osx/make_osx
+++ b/contrib/osx/make_osx
@@ -3,7 +3,7 @@
 # Parameterize
 PYTHON_VERSION=3.7.9
 BUILDDIR=/tmp/electrum-build
-PACKAGE=ElectrumCash
+PACKAGE=ELCASHWallet
 GIT_REPO=https://github.com/electric-cash/electrum-cash
 
 export GCC_STRIP_BINARIES="1"


### PR DESCRIPTION
Fix package name in macOS build script
:right_anger_bubble: ERROR: Could not add keys to Info.plist. Make sure the program ‘plutil’ exists and is installed.