### PR TITLE
fix: remove unused import

### DIFF
--- a/electrum/gui/qt/settings_dialog.py
+++ b/electrum/gui/qt/settings_dialog.py
@@ -34,8 +34,6 @@ from PyQt5.QtWidgets import (QComboBox,  QTabWidget,
 from electrum.i18n import _, languages
 from electrum import util, coinchooser, paymentrequest
 
-from electrum.gui import messages
-
 from electrum.util import base_units_list
 
 from .util import (ColorScheme, WindowModalDialog, HelpLabel, Buttons,


### PR DESCRIPTION
What does this PR do?
- fix crash bug caused by missing, unneeded import